### PR TITLE
remove trailing comma from use type statement

### DIFF
--- a/src/TypeSpec/__Private/TraversableSpec.php
+++ b/src/TypeSpec/__Private/TraversableSpec.php
@@ -13,7 +13,7 @@ namespace Facebook\TypeSpec\__Private;
 use type Facebook\TypeAssert\{
   IncorrectTypeException,
   UnsupportedTypeException,
-  TypeCoercionException,
+  TypeCoercionException
 };
 use type Facebook\TypeSpec\TypeSpec;
 use namespace HH\Lib\Vec;


### PR DESCRIPTION
I know 3.21.0 may not necessarily be supported for much longer, but using its `hh_client` on master generates
```src/TypeSpec/__Private/TraversableSpec.php:17:1,1: Expected identifier (Parsing[1002])```
which seems like https://github.com/facebook/hhvm/issues/7397.