### PR TITLE
Fix typo in README example function name

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ either return it unmodified (but with type data) or throw an exception; for exam
 ```Hack
 <?hh // strict
 use namespace Facebook\TypeAssert;
-function need_string(string $bar): void {
+function needs_string(string $bar): void {
 }
 
 function main(): void {


### PR DESCRIPTION
This fixes a minor typo in the README's sample code.

The first code example in the Usage section defines a function `need_string`, but then later refers to it as `needs_string`. The other examples all use the name `needs_string`, so this changes `need_string` => `needs_string`.