### PR TITLE
Lambda and lval

### DIFF
--- a/src/TypeSpec/__Private/SetSpec.hack
+++ b/src/TypeSpec/__Private/SetSpec.hack
@@ -37,7 +37,7 @@ final class SetSpec<Tv as arraykey, T as \ConstSet<Tv>> extends TypeSpec<T> {
     }
 
     $trace = $this->getTrace()->withFrame($this->what.'<T>');
-    $map = $container ==>
+    $map = (\ConstSet<arraykey> $container) ==>
       $container->map($v ==> $this->inner->withTrace($trace)->coerceType($v));
 
     if (\is_a($value, $this->what)) {

--- a/src/TypeSpec/__Private/VecLikeArraySpec.hack
+++ b/src/TypeSpec/__Private/VecLikeArraySpec.hack
@@ -41,9 +41,8 @@ final class VecLikeArraySpec<T> extends TypeSpec<array<T>> {
 
     $counter = (
       function(): \Generator<int, int, void> {
-        $i = 0;
-        while (true) {
-          yield $i++;
+        for ($i = 0; true; $i++) {
+          yield $i;
         }
       }
     )();

--- a/src/TypeSpec/__Private/VectorSpec.hack
+++ b/src/TypeSpec/__Private/VectorSpec.hack
@@ -37,7 +37,7 @@ final class VectorSpec<Tv, T as \ConstVector<Tv>> extends TypeSpec<T> {
     }
 
     $trace = $this->getTrace()->withFrame($this->what.'<T>');
-    $map = $container ==>
+    $map = (\ConstVector<mixed> $container) ==>
       $container->map($v ==> $this->inner->withTrace($trace)->coerceType($v));
 
     if (\is_a($value, $this->what)) {


### PR DESCRIPTION
Summary: required for .hhconfig disable_lval_as_an_expression and disallow_ambiguous_lambda.