### PR TITLE
Bugfix/negative intspec

### DIFF
--- a/src/TypeSpec/__Private/IntSpec.hack
+++ b/src/TypeSpec/__Private/IntSpec.hack
@@ -22,8 +22,9 @@ final class IntSpec extends TypeSpec<int> {
     if ($value instanceof \Stringish) {
       /* HH_FIXME[4281] Stringish is going */
       $str = (string)$value;
-      if ($str !== '' && \ctype_digit($str)) {
-        return (int)$str;
+      $int = (int)$str;
+      if ($str === (string)$int) {
+        return $int;
       }
     }
     throw TypeCoercionException::withValue($this->getTrace(), 'int', $value);

--- a/src/TypeSpec/__Private/IntSpec.hack
+++ b/src/TypeSpec/__Private/IntSpec.hack
@@ -24,12 +24,24 @@ final class IntSpec extends TypeSpec<int> {
       /* HH_FIXME[4281] Stringish is going */
       $str = (string)$value;
       $int = (int)$str;
+
+      // "1234"   -(int)->   1234   -(string)->   "1234"
+      // "-1234"  -(int)->   -1234  -(string)->   "-1234"
+      //   ^^           are the same                ^^
       if ($str === (string)$int) {
         return $int;
       }
+
+      // "0001234" -(trim)-> "1234" -(int)-> 1234 -(string)-> "1234"
+      //                       ^^        are the same           ^^
       $str = Str\trim_left($str, '0');
       if ($str === (string)$int) {
         return $int;
+      }
+
+      // Exceptional case "000" -(trim)-> "", but we want to return 0
+      if ($str === '' && $value !== '') {
+        return 0;
       }
     }
     throw TypeCoercionException::withValue($this->getTrace(), 'int', $value);

--- a/src/TypeSpec/__Private/IntSpec.hack
+++ b/src/TypeSpec/__Private/IntSpec.hack
@@ -12,6 +12,7 @@ namespace Facebook\TypeSpec\__Private;
 
 use type Facebook\TypeAssert\{IncorrectTypeException, TypeCoercionException};
 use type Facebook\TypeSpec\TypeSpec;
+use namespace HH\Lib\Str;
 
 final class IntSpec extends TypeSpec<int> {
   <<__Override>>
@@ -23,6 +24,10 @@ final class IntSpec extends TypeSpec<int> {
       /* HH_FIXME[4281] Stringish is going */
       $str = (string)$value;
       $int = (int)$str;
+      if ($str === (string)$int) {
+        return $int;
+      }
+      $str = Str\trim_left($str, '0');
       if ($str === (string)$int) {
         return $int;
       }

--- a/tests/IntSpecTest.hack
+++ b/tests/IntSpecTest.hack
@@ -12,6 +12,7 @@ namespace Facebook\TypeAssert;
 
 use namespace Facebook\TypeSpec;
 use type Facebook\TypeSpec\TypeSpec;
+use namespace HH\Lib\Math;
 
 final class IntSpecTest extends TypeSpecTest<int> {
   <<__Override>>
@@ -27,7 +28,9 @@ final class IntSpecTest extends TypeSpecTest<int> {
       tuple('0', 0),
       tuple('123', 123),
       tuple(new TestStringable('123'), 123),
+      tuple((string)Math\INT64_MAX, Math\INT64_MAX),
       tuple('-321', -321),
+      tuple((string)Math\INT64_MIN, Math\INT64_MIN),
       tuple(new TestStringable('-321'), -321),
       tuple('007', 7),
       tuple('000', 0),
@@ -50,7 +53,8 @@ final class IntSpecTest extends TypeSpecTest<int> {
       [new TestStringable('1.23')],
       ['-007'],
       [new TestStringable('-007')],
-      ['9223372036854775808'],
+      ['9223372036854775808'], //Math\INT64_MAX+1
+      ['-9223372036854775809'], //Math\INT64_MIN-1
     ];
   }
 }

--- a/tests/IntSpecTest.hack
+++ b/tests/IntSpecTest.hack
@@ -49,6 +49,7 @@ final class IntSpecTest extends TypeSpecTest<int> {
       ['007'],
       ['-007'],
       [new TestStringable('-007')],
+      ['9223372036854775808'],
     ];
   }
 }

--- a/tests/IntSpecTest.hack
+++ b/tests/IntSpecTest.hack
@@ -27,6 +27,8 @@ final class IntSpecTest extends TypeSpecTest<int> {
       tuple('0', 0),
       tuple('123', 123),
       tuple(new TestStringable('123'), 123),
+      tuple('-321', -321),
+      tuple(new TestStringable('-321'), -321),
     ];
   }
 

--- a/tests/IntSpecTest.hack
+++ b/tests/IntSpecTest.hack
@@ -30,6 +30,7 @@ final class IntSpecTest extends TypeSpecTest<int> {
       tuple('-321', -321),
       tuple(new TestStringable('-321'), -321),
       tuple('007', 7),
+      tuple('000', 0),
     ];
   }
 

--- a/tests/IntSpecTest.hack
+++ b/tests/IntSpecTest.hack
@@ -54,7 +54,8 @@ final class IntSpecTest extends TypeSpecTest<int> {
       ['-007'],
       [new TestStringable('-007')],
       ['9223372036854775808'], //Math\INT64_MAX+1
-      ['-9223372036854775809'], //Math\INT64_MIN-1
+      ['-9223372036854775809'], //Math\INT64_MIN-1,
+      ['0xFF'],
     ];
   }
 }

--- a/tests/IntSpecTest.hack
+++ b/tests/IntSpecTest.hack
@@ -29,6 +29,7 @@ final class IntSpecTest extends TypeSpecTest<int> {
       tuple(new TestStringable('123'), 123),
       tuple('-321', -321),
       tuple(new TestStringable('-321'), -321),
+      tuple('007', 7),
     ];
   }
 
@@ -46,7 +47,6 @@ final class IntSpecTest extends TypeSpecTest<int> {
       [null],
       [false],
       [new TestStringable('1.23')],
-      ['007'],
       ['-007'],
       [new TestStringable('-007')],
       ['9223372036854775808'],

--- a/tests/IntSpecTest.hack
+++ b/tests/IntSpecTest.hack
@@ -46,6 +46,9 @@ final class IntSpecTest extends TypeSpecTest<int> {
       [null],
       [false],
       [new TestStringable('1.23')],
+      ['007'],
+      ['-007'],
+      [new TestStringable('-007')],
     ];
   }
 }

--- a/tests/IntSpecTest.hack
+++ b/tests/IntSpecTest.hack
@@ -54,7 +54,7 @@ final class IntSpecTest extends TypeSpecTest<int> {
       ['-007'],
       [new TestStringable('-007')],
       ['9223372036854775808'], //Math\INT64_MAX+1
-      ['-9223372036854775809'], //Math\INT64_MIN-1,
+      ['-9223372036854775809'], //Math\INT64_MIN-1
       ['0xFF'],
     ];
   }


### PR DESCRIPTION
Fixes #26
The HSL uses this check too. https://github.com/hhvm/hsl/blob/1e3691dc7d3f5dbb3c48082df9a43eab90cabfa0/src/str/transform.php#L285
There is a regression here though. Previously '007' would coerce to int(7), but now this will become invalid.
I don't know if this is something that would cause problems.