### PR TITLE
Support reified generics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 language: generic
 services: docker
 env:
-- HHVM_VERSION=4.13-latest
+- HHVM_VERSION=4.16-latest
 - HHVM_VERSION=latest
 - HHVM_VERSION=nightly
 install:

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "keywords": ["hack", "TypeAssert" ],
   "require": {
-    "hhvm": "^4.13",
+    "hhvm": "^4.16",
     "hhvm/hsl": "^4.0"
   },
   "extra": {

--- a/src/TypeAssert.hack
+++ b/src/TypeAssert.hack
@@ -42,11 +42,7 @@ function arraykey(mixed $x): arraykey {
 
 function not_null<T>(?T $x): T {
   if ($x === null) {
-    throw new IncorrectTypeException(
-      new TypeSpec\Trace(),
-      'not-null',
-      'null',
-    );
+    throw new IncorrectTypeException(new TypeSpec\Trace(), 'not-null', 'null');
   }
   return $x;
 }
@@ -61,4 +57,11 @@ function classname_of<T>(classname<T> $expected, string $what): classname<T> {
 
 function matches_type_structure<T>(TypeStructure<T> $ts, mixed $value): T {
   return TypeSpec\__Private\from_type_structure($ts)->assertType($value);
+}
+
+function matches<reify T>(mixed $value): T {
+  return matches_type_structure(
+    \HH\ReifiedGenerics\getTypeStructure<T>(),
+    $value,
+  );
 }

--- a/src/TypeCoerce.hack
+++ b/src/TypeCoerce.hack
@@ -43,3 +43,10 @@ function arraykey(mixed $x): arraykey {
 function match_type_structure<T>(TypeStructure<T> $ts, mixed $value): T {
   return TypeSpec\__Private\from_type_structure($ts)->coerceType($value);
 }
+
+function match<reify T>(mixed $value): T {
+  return match_type_structure(
+    \HH\ReifiedGenerics\getTypeStructure<T>(),
+    $value,
+  );
+}

--- a/src/TypeSpec/__Private/DictSpec.hack
+++ b/src/TypeSpec/__Private/DictSpec.hack
@@ -10,7 +10,7 @@
 
 namespace Facebook\TypeSpec\__Private;
 
-use type Facebook\TypeAssert\TypeCoercionException;
+use type Facebook\TypeAssert\{IncorrectTypeException, TypeCoercionException};
 use type Facebook\TypeSpec\TypeSpec;
 use namespace HH\Lib\Dict;
 
@@ -45,7 +45,7 @@ final class DictSpec<Tk as arraykey, Tv> extends TypeSpec<dict<Tk, Tv>> {
   <<__Override>>
   public function assertType(mixed $value): dict<Tk, Tv> {
     if (!($value is dict<_, _>)) {
-      throw TypeCoercionException::withValue(
+      throw IncorrectTypeException::withValue(
         $this->getTrace(),
         'dict<Tk, Tv>',
         $value,

--- a/tests/ReifiedGenericsTest.hack
+++ b/tests/ReifiedGenericsTest.hack
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (c) 2016, Fred Emmott
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\TypeAssert;
+
+use namespace Facebook\TypeCoerce;
+
+use function Facebook\FBExpect\expect;
+
+final class ReifiedGenericsTest extends \Facebook\HackTest\HackTest {
+  const type TString = string;
+
+  public function testString(): void {
+    expect(matches<this::TString>('foo'))->toBeSame('foo');
+    expect(() ==> matches<this::TString>(123))
+      ->toThrow(IncorrectTypeException::class);
+  }
+
+  const type TVecOfStrings = vec<string>;
+
+  public function testVecOfStrings(): void {
+    expect(matches<this::TVecOfStrings>(vec['foo', 'bar']))
+      ->toBeSame(vec['foo', 'bar']);
+    expect(() ==> matches<this::TVecOfStrings>(vec[123, 123]))
+      ->toThrow(IncorrectTypeException::class);
+  }
+
+  const type TShapeOfVecAndDicts = shape(
+    'vec' => vec<string>,
+    'dict' => dict<int, int>,
+  );
+
+  public function testShapeOfVecAndDicts(): void {
+    $valid = shape('vec' => vec['foo', 'bar'], 'dict' => dict[1 => 2]);
+    $coercable = dict['vec' => vec['foo', 'bar'], 'dict' => darray[1 => 2]];
+    expect(matches<this::TShapeOfVecAndDicts>($valid))->toBeSame($valid);
+    expect(() ==> matches<this::TShapeOfVecAndDicts>($coercable))
+      ->toThrow(IncorrectTypeException::class);
+    expect(TypeCoerce\match<this::TShapeOfVecAndDicts>($coercable))
+      ->toBeSame($valid);
+    expect(() ==> TypeCoerce\match<this::TShapeOfVecAndDicts>('hello'))
+      ->toThrow(TypeCoercionException::class);
+  }
+}


### PR DESCRIPTION
Just wrapping the old implementations for now.

The builtins should be snake_case; FB D16626808 will add them as aliases
before full release.

Also fix an incorrect exception being thrown by DictSpec, found while
writing the test.