### PR TITLE
Make non-test code use darray, instead of php-array

### DIFF
--- a/src/TypeSpec/__Private/UntypedArraySpec.hack
+++ b/src/TypeSpec/__Private/UntypedArraySpec.hack
@@ -39,10 +39,6 @@ final class UntypedArraySpec extends TypeSpec<array> {
         IncorrectTypeException::withValue($this->getTrace(), 'array', $value);
     }
 
-    $out = darray[];
-    foreach ($value as $k => $v) {
-      $out[$k] = $v;
-    }
-    return $out;
+    return $value;
   }
 }

--- a/src/TypeSpec/__Private/UntypedArraySpec.hack
+++ b/src/TypeSpec/__Private/UntypedArraySpec.hack
@@ -24,7 +24,7 @@ final class UntypedArraySpec extends TypeSpec<array> {
         TypeCoercionException::withValue($this->getTrace(), 'array', $value);
     }
 
-    $out = [];
+    $out = darray[];
     foreach ($value as $k => $v) {
       $out[$k as arraykey] = $v;
     }
@@ -39,7 +39,7 @@ final class UntypedArraySpec extends TypeSpec<array> {
         IncorrectTypeException::withValue($this->getTrace(), 'array', $value);
     }
 
-    $out = [];
+    $out = darray[];
     foreach ($value as $k => $v) {
       $out[$k] = $v;
     }


### PR DESCRIPTION
This disallow_array_literal option can not be left on,
because hhvm 4.24 can't typecheck its own HHI's that strictly.
This option can be enabled after hhvm 4.25+ is the minimum version.