### PR TITLE
Use the hybrid type `darray_or_varray`

### DIFF
--- a/.hhconfig
+++ b/.hhconfig
@@ -7,3 +7,4 @@ disallow_destruct = true
 disallow_invalid_arraykey = true
 disallow_stringish_magic = true
 user_attributes=
+disallow_array_literal = true

--- a/.hhconfig
+++ b/.hhconfig
@@ -7,4 +7,7 @@ disallow_destruct = true
 disallow_invalid_arraykey = true
 disallow_stringish_magic = true
 user_attributes=
-disallow_array_literal = true
+
+; The tests require many php arrays to get good coverage.
+; This setting is intentionally turned off.
+disallow_array_literal = false

--- a/src/TypeSpec/__Private/UntypedArraySpec.hack
+++ b/src/TypeSpec/__Private/UntypedArraySpec.hack
@@ -13,17 +13,20 @@ namespace Facebook\TypeSpec\__Private;
 use type Facebook\TypeAssert\{IncorrectTypeException, TypeCoercionException};
 use type Facebook\TypeSpec\TypeSpec;
 
-/* HH_IGNORE_ERROR[4045] array without generics */
-final class UntypedArraySpec extends TypeSpec<array> {
+/* HH_IGNORE_ERROR[2071] varray_or_darray without generics */
+final class UntypedArraySpec extends TypeSpec<varray_or_darray> {
 
   <<__Override>>
-  /* HH_IGNORE_ERROR[4045] array without generics */
-  public function coerceType(mixed $value): array {
+  /* HH_IGNORE_ERROR[2071] varray_or_darray without generics */
+  public function coerceType(mixed $value): varray_or_darray {
     if (!$value is KeyedTraversable<_, _>) {
       throw
         TypeCoercionException::withValue($this->getTrace(), 'array', $value);
     }
 
+    /*HH_IGNORE_ERROR[2083]
+      we are intentionally making a varray_or_darray,
+      so we need the PHP syntax*/
     $out = [];
     foreach ($value as $k => $v) {
       $out[$k as arraykey] = $v;
@@ -32,13 +35,16 @@ final class UntypedArraySpec extends TypeSpec<array> {
   }
 
   <<__Override>>
-  /* HH_IGNORE_ERROR[4045] array without generics */
-  public function assertType(mixed $value): array {
+  /* HH_IGNORE_ERROR[2071] varray_or_darray without generics */
+  public function assertType(mixed $value): varray_or_darray {
     if (!\is_array($value)) {
       throw
         IncorrectTypeException::withValue($this->getTrace(), 'array', $value);
     }
 
+    /*HH_IGNORE_ERROR[2083]
+      we are intentionally making a varray_or_darray,
+      so we need the PHP syntax*/
     $out = [];
     foreach ($value as $k => $v) {
       $out[$k] = $v;


### PR DESCRIPTION
PR #37 is using a `darray` for this. This may cause issues.
This downgrades to the safer combo of the two.
This is not changing the runtime or typecheck behavior in 4.29,
since by default, all php arrays are now `varray_or_darray`