### PR TITLE
Disable the lint rule against plain array literals

### DIFF
--- a/hhast-lint.json
+++ b/hhast-lint.json
@@ -1,4 +1,14 @@
 {
   "roots": [ "src/", "tests/" ],
-  "builtinLinters": "all"
+  "builtinLinters": "all",
+  "overrides": [
+    {
+      "patterns": [
+        "*"
+      ],
+      "disabledLinters": [
+        "Facebook\\HHAST\\NoPHPArrayLiteralsLinter"
+      ]
+    }
+  ]
 }

--- a/hhast-lint.json
+++ b/hhast-lint.json
@@ -4,7 +4,7 @@
   "overrides": [
     {
       "patterns": [
-        "*"
+        "tests/**"
       ],
       "disabledLinters": [
         "Facebook\\HHAST\\NoPHPArrayLiteralsLinter"


### PR DESCRIPTION
This projects job is to work with these arrays.
It should not be required to update the code to use dict/vec.
That would break the purpose of many tests.
Making an exception to the linter rules.