### PR TITLE
Use stringish cast

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 language: generic
 services: docker
 env:
-- HHVM_VERSION=4.17-latest
+- HHVM_VERSION=4.20-latest
 - HHVM_VERSION=latest
 - HHVM_VERSION=nightly
 install:

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "keywords": ["hack", "TypeAssert" ],
   "require": {
-    "hhvm": "^4.17",
+    "hhvm": "^4.20",
     "hhvm/hsl": "^4.0"
   },
   "extra": {

--- a/src/TypeSpec/__Private/FloatSpec.hack
+++ b/src/TypeSpec/__Private/FloatSpec.hack
@@ -27,8 +27,7 @@ final class FloatSpec extends TypeSpec<float> {
     }
 
     if ($value is \Stringish) {
-      /* HH_FIXME[4281] Stringish is going */
-      $str = (string)$value;
+      $str = stringish_cast($value, __CLASS__.__METHOD__);
       if ($str === '') {
         throw TypeCoercionException::withValue(
           $this->getTrace(),

--- a/src/TypeSpec/__Private/FloatSpec.hack
+++ b/src/TypeSpec/__Private/FloatSpec.hack
@@ -27,7 +27,7 @@ final class FloatSpec extends TypeSpec<float> {
     }
 
     if ($value is \Stringish) {
-      $str = stringish_cast($value, __CLASS__.__METHOD__);
+      $str = stringish_cast($value, __CLASS__.'::'.__METHOD__);
       if ($str === '') {
         throw TypeCoercionException::withValue(
           $this->getTrace(),

--- a/src/TypeSpec/__Private/IntSpec.hack
+++ b/src/TypeSpec/__Private/IntSpec.hack
@@ -21,8 +21,7 @@ final class IntSpec extends TypeSpec<int> {
       return $value;
     }
     if ($value is \Stringish) {
-      /* HH_FIXME[4281] Stringish is going */
-      $str = (string)$value;
+      $str = stringish_cast($value, __CLASS__.__METHOD__);
       $int = (int)$str;
 
       // "1234"   -(int)->   1234   -(string)->   "1234"

--- a/src/TypeSpec/__Private/IntSpec.hack
+++ b/src/TypeSpec/__Private/IntSpec.hack
@@ -21,7 +21,7 @@ final class IntSpec extends TypeSpec<int> {
       return $value;
     }
     if ($value is \Stringish) {
-      $str = stringish_cast($value, __CLASS__.__METHOD__);
+      $str = stringish_cast($value, __CLASS__.'::'.__METHOD__);
       $int = (int)$str;
 
       // "1234"   -(int)->   1234   -(string)->   "1234"

--- a/src/TypeSpec/__Private/StringSpec.hack
+++ b/src/TypeSpec/__Private/StringSpec.hack
@@ -20,7 +20,7 @@ final class StringSpec extends TypeSpec<string> {
       return $value;
     }
     if ($value is \Stringish) {
-      return stringish_cast($value, __CLASS__.__METHOD__);
+      return stringish_cast($value, __CLASS__.'::'.__METHOD__);
     }
     if ($value is int) {
       return (string)$value;

--- a/src/TypeSpec/__Private/StringSpec.hack
+++ b/src/TypeSpec/__Private/StringSpec.hack
@@ -20,8 +20,7 @@ final class StringSpec extends TypeSpec<string> {
       return $value;
     }
     if ($value is \Stringish) {
-      /* HH_FIXME[4281] Stringish is going */
-      return (string)$value;
+      return stringish_cast($value, __CLASS__.__METHOD__);
     }
     if ($value is int) {
       return (string)$value;
@@ -34,7 +33,10 @@ final class StringSpec extends TypeSpec<string> {
     if ($value is string) {
       return $value;
     }
-    throw
-      new IncorrectTypeException($this->getTrace(), 'string', \gettype($value));
+    throw new IncorrectTypeException(
+      $this->getTrace(),
+      'string',
+      \gettype($value),
+    );
   }
 }

--- a/src/TypeSpec/__Private/stringish_cast.hack
+++ b/src/TypeSpec/__Private/stringish_cast.hack
@@ -8,7 +8,7 @@ function stringish_cast(\Stringish $stringish, string $caller): string {
       'Stringish is being deprecated. '.
       'Passing an object that implements __toString to '.
       $caller.
-      ' may not work in a future release.',
+      '() may not work in a future release.',
       \E_USER_DEPRECATED,
     );
     /*HH_FIXME[4128] stringish_cast() can't be used in the future.*/

--- a/src/TypeSpec/__Private/stringish_cast.hack
+++ b/src/TypeSpec/__Private/stringish_cast.hack
@@ -8,7 +8,7 @@ function stringish_cast(\Stringish $stringish, string $caller): string {
       'Stringish is being deprecated. '.
       'Passing an object that implements __toString to '.
       $caller.
-      'FloatSpec::coerceType may not work in a future release.',
+      ' may not work in a future release.',
       \E_USER_DEPRECATED,
     );
     /*HH_FIXME[4128] stringish_cast() can't be used in the future.*/

--- a/src/TypeSpec/__Private/stringish_cast.hack
+++ b/src/TypeSpec/__Private/stringish_cast.hack
@@ -1,0 +1,17 @@
+namespace Facebook\TypeSpec\__Private;
+
+function stringish_cast(\Stringish $stringish, string $caller): string {
+  if ($stringish is string) {
+    return $stringish;
+  } else {
+    \trigger_error(
+      'Stringish is being deprecated. '.
+      'Passing an object that implements __toString to '.
+      $caller.
+      'FloatSpec::coerceType may not work in a future release.',
+      \E_USER_DEPRECATED,
+    );
+    /*HH_FIXME[4128] stringish_cast() can't be used in the future.*/
+    return $stringish->__toString();
+  }
+}

--- a/src/TypeSpec/__Private/stringish_cast.hack
+++ b/src/TypeSpec/__Private/stringish_cast.hack
@@ -3,6 +3,8 @@ namespace Facebook\TypeSpec\__Private;
 function stringish_cast(\Stringish $stringish, string $caller): string {
   if ($stringish is string) {
     return $stringish;
+  } else if (\HH\is_fun($stringish)) {
+    return \HH\fun_get_function($stringish);
   } else {
     \trigger_error(
       'Stringish is being deprecated. '.


### PR DESCRIPTION
`(string) $obj_or_string` is becoming illegal.
Typeassert is mostly used in cases where the type is unknown, preventing the typechecker from warning us.
I think it would be a good migration plan to start issuing runtime warnings.

Also, `Stringish::__toString()`'s deprecation mentions `stringish_cast` by name, but the typechecker couldn't find it in the latest nightly.