### PR TITLE
Add <<__Memoize>> on Private\from_type_structure

### DIFF
--- a/src/TypeSpec/__Private/from_type_structure.hack
+++ b/src/TypeSpec/__Private/from_type_structure.hack
@@ -15,6 +15,7 @@ use type Facebook\TypeSpec\TypeSpec;
 use namespace HH\Lib\{C, Dict, Vec};
 use namespace Facebook\{TypeAssert, TypeSpec};
 
+<<__Memoize>>
 function from_type_structure<T>(TypeStructure<T> $ts): TypeSpec<T> {
   if ($ts['optional_shape_field'] ?? false) {
     $ts['optional_shape_field'] = false;


### PR DESCRIPTION
TypeSpec<T> is a stateless object and quite expensive to create.
This function will always have the same output for the same input.
This does change the observable behavior, because `===` will be true.
I don't think this is a problem to most.