### PR TITLE
Strip out shape logic for hhvm 3.22 and below

### DIFF
--- a/src/TypeSpec/__Private/ShapeSpec.hack
+++ b/src/TypeSpec/__Private/ShapeSpec.hack
@@ -15,17 +15,10 @@ use type Facebook\TypeSpec\TypeSpec;
 use namespace HH\Lib\C;
 
 final class ShapeSpec extends TypeSpec<shape()> {
-  const bool STRICT_SHAPES = \HHVM_VERSION_ID >= 32300;
   private bool $allowUnknownFields;
 
   private static function isOptionalField<Tany>(TypeSpec<Tany> $spec): bool {
-    if ($spec->isOptional()) {
-      return true;
-    }
-    if (self::STRICT_SHAPES) {
-      return false;
-    }
-    return $spec is NullableSpec<_>;
+    return $spec->isOptional();
   }
 
   public function __construct(

--- a/src/TypeSpec/__Private/from_type_structure.hack
+++ b/src/TypeSpec/__Private/from_type_structure.hack
@@ -114,7 +114,7 @@ function from_type_structure<T>(TypeStructure<T> $ts): TypeSpec<T> {
           ($_k, $field_ts) ==> from_type_structure($field_ts),
           ($k, $_v) ==> $k,
         ),
-        $ts['allows_unknown_fields']
+        ($ts['allows_unknown_fields'] ?? false)
           ? UnknownFieldsMode::ALLOW
           : UnknownFieldsMode::DENY,
       );

--- a/src/TypeSpec/__Private/from_type_structure.hack
+++ b/src/TypeSpec/__Private/from_type_structure.hack
@@ -114,8 +114,7 @@ function from_type_structure<T>(TypeStructure<T> $ts): TypeSpec<T> {
           ($_k, $field_ts) ==> from_type_structure($field_ts),
           ($k, $_v) ==> $k,
         ),
-        /* HH_FIXME[4108] 3.21 is not aware of allows_unknown_fields */
-        ($ts['allows_unknown_fields'] ?? !ShapeSpec::STRICT_SHAPES)
+        $ts['allows_unknown_fields']
           ? UnknownFieldsMode::ALLOW
           : UnknownFieldsMode::DENY,
       );

--- a/tests/TypeStructureTest.hack
+++ b/tests/TypeStructureTest.hack
@@ -456,18 +456,16 @@ final class TypeStructureTest extends \Facebook\HackTest\HackTest {
       ),
     ];
 
-    if (\HHVM_VERSION_ID >= 32300) {
-      $examples['shape with missing nullable field'] = tuple(
-        type_structure(TypeConstants::class, 'TFlatShape'),
-        shape('someString' => 'foo'),
-        vec['shape[someNullable]'],
-      );
-      $examples['shape with extra fields'] = tuple(
-        type_structure(TypeConstants::class, 'TShapeWithOneField'),
-        shape('someString' => 'string', 'herp' => 'derp'),
-        vec['shape[herp]'],
-      );
-    }
+    $examples['shape with missing nullable field'] = tuple(
+      type_structure(TypeConstants::class, 'TFlatShape'),
+      shape('someString' => 'foo'),
+      vec['shape[someNullable]'],
+    );
+    $examples['shape with extra fields'] = tuple(
+      type_structure(TypeConstants::class, 'TShapeWithOneField'),
+      shape('someString' => 'string', 'herp' => 'derp'),
+      vec['shape[herp]'],
+    );
     return $examples;
   }
 
@@ -543,19 +541,11 @@ final class TypeStructureTest extends \Facebook\HackTest\HackTest {
       ),
     ];
 
-    if (\HHVM_VERSION_ID >= 32300) {
-      $coercions['shape with extra fields'] = tuple(
-        type_structure(TypeConstants::class, 'TShapeWithOneField'),
-        shape('someString' => 'foo', 'herp' => 'derp'),
-        shape('someString' => 'foo'),
-      );
-    } else {
-      $coercions['shape with extra fields'] = tuple(
-        type_structure(TypeConstants::class, 'TShapeWithOneField'),
-        shape('someString' => 'foo', 'herp' => 'derp'),
-        shape('someString' => 'foo', 'herp' => 'derp'),
-      );
-    }
+    $coercions['shape with extra fields'] = tuple(
+      type_structure(TypeConstants::class, 'TShapeWithOneField'),
+      shape('someString' => 'foo', 'herp' => 'derp'),
+      shape('someString' => 'foo'),
+    );
 
     return Dict\map(
       $this->getExampleValidTypes(),


### PR DESCRIPTION
Shapes are explicitly subtyped, instead of the old implicit rules
These version switches do nothing more than complicate the code