### PR TITLE
Add TypeSpec\of<reify T>() and type-structure based variant

### DIFF
--- a/src/TypeAssert.hack
+++ b/src/TypeAssert.hack
@@ -56,12 +56,9 @@ function classname_of<T>(classname<T> $expected, string $what): classname<T> {
 }
 
 function matches_type_structure<T>(TypeStructure<T> $ts, mixed $value): T {
-  return TypeSpec\__Private\from_type_structure($ts)->assertType($value);
+  return TypeSpec\of_type_structure($ts)->assertType($value);
 }
 
 function matches<reify T>(mixed $value): T {
-  return matches_type_structure(
-    \HH\ReifiedGenerics\get_type_structure<T>(),
-    $value,
-  );
+  return TypeSpec\of<T>()->assertType($value);
 }

--- a/src/TypeAssert.hack
+++ b/src/TypeAssert.hack
@@ -56,7 +56,7 @@ function classname_of<T>(classname<T> $expected, string $what): classname<T> {
 }
 
 function matches_type_structure<T>(TypeStructure<T> $ts, mixed $value): T {
-  return TypeSpec\of_type_structure($ts)->assertType($value);
+  return TypeSpec\__Private\from_type_structure($ts)->assertType($value);
 }
 
 function matches<reify T>(mixed $value): T {

--- a/src/TypeCoerce.hack
+++ b/src/TypeCoerce.hack
@@ -41,12 +41,9 @@ function arraykey(mixed $x): arraykey {
 }
 
 function match_type_structure<T>(TypeStructure<T> $ts, mixed $value): T {
-  return TypeSpec\__Private\from_type_structure($ts)->coerceType($value);
+  return TypeSpec\of_type_structure($ts)->coerceType($value);
 }
 
 function match<reify T>(mixed $value): T {
-  return match_type_structure(
-    \HH\ReifiedGenerics\get_type_structure<T>(),
-    $value,
-  );
+  return TypeSpec\of<T>()->coerceType($value);
 }

--- a/src/TypeCoerce.hack
+++ b/src/TypeCoerce.hack
@@ -41,7 +41,7 @@ function arraykey(mixed $x): arraykey {
 }
 
 function match_type_structure<T>(TypeStructure<T> $ts, mixed $value): T {
-  return TypeSpec\of_type_structure($ts)->coerceType($value);
+  return TypeSpec\__Private\from_type_structure($ts)->coerceType($value);
 }
 
 function match<reify T>(mixed $value): T {

--- a/src/TypeSpec.hack
+++ b/src/TypeSpec.hack
@@ -177,10 +177,8 @@ function varray_or_darray<Tv>(
   return new __Private\VArrayOrDArraySpec($inner);
 }
 
-function of_type_structure<T>(TypeStructure<T> $ts): TypeSpec<T> {
-  return __Private\from_type_structure($ts);
-}
-
 function of<reify T>(): TypeSpec<T> {
-  return of_type_structure(\HH\ReifiedGenerics\get_type_structure<T>());
+  return __Private\from_type_structure(
+    \HH\ReifiedGenerics\get_type_structure<T>(),
+  );
 }

--- a/src/TypeSpec.hack
+++ b/src/TypeSpec.hack
@@ -176,3 +176,11 @@ function varray_or_darray<Tv>(
 ): TypeSpec<varray_or_darray<Tv>> {
   return new __Private\VArrayOrDArraySpec($inner);
 }
+
+function of_type_structure<T>(TypeStructure<T> $ts): TypeSpec<T> {
+  return __Private\from_type_structure($ts);
+}
+
+function of<reify T>(): TypeSpec<T> {
+  return of_type_structure(\HH\ReifiedGenerics\get_type_structure<T>());
+}

--- a/src/TypeSpec/__Private/ShapeSpec.hack
+++ b/src/TypeSpec/__Private/ShapeSpec.hack
@@ -133,7 +133,7 @@ final class ShapeSpec extends TypeSpec<shape()> {
           $spec->toString(),
         ),
       )
-      |> $this->allowUnknownFields ? Vec\concat($$, vec['...']) : $$
+      |> $this->allowUnknownFields ? Vec\concat($$, vec['  ...']) : $$
       |> Str\join($$, "\n")
       |> "shape(\n".$$."\n)";
   }

--- a/tests/ReifiedGenericsTest.hack
+++ b/tests/ReifiedGenericsTest.hack
@@ -10,7 +10,7 @@
 
 namespace Facebook\TypeAssert;
 
-use namespace Facebook\TypeCoerce;
+use namespace Facebook\{TypeCoerce, TypeSpec};
 
 use function Facebook\FBExpect\expect;
 
@@ -47,5 +47,24 @@ final class ReifiedGenericsTest extends \Facebook\HackTest\HackTest {
       ->toBeSame($valid);
     expect(() ==> TypeCoerce\match<this::TShapeOfVecAndDicts>('hello'))
       ->toThrow(TypeCoercionException::class);
+  }
+
+  public function testInlineTypes(): void {
+    $valid = shape('foo' => 123);
+    $coercable = shape('foo' => '123');
+    expect(matches<shape('foo' => int)>($valid))->toEqual($valid);
+    expect(matches<shape('foo' => int, ...)>($valid))->toEqual($valid);
+    expect(TypeCoerce\match<shape('foo' => int, ...)>($valid))->toEqual($valid);
+    expect(TypeCoerce\match<shape('foo' => int, ...)>($coercable))->toEqual(
+      $valid,
+    );
+  }
+
+  public function testToString(): void {
+    expect(TypeSpec\of<shape('foo' => vec<string>)>()->toString())->toEqual(
+      "shape(\n  'foo' => HH\\vec<string>,\n)",
+    );
+    expect(TypeSpec\of<shape('foo' => vec<string>, ...)>()->toString())
+      ->toEqual("shape(\n  'foo' => HH\\vec<string>,\n  ...\n)");
   }
 }


### PR DESCRIPTION
- originally didn't add because naming is hard. Match FB naming
- something like this is needed for potential release of FB stuff
- would have made a load of the tests I recently added a lot clearer...