### PR TITLE
Compatibility with 4.62 and current nightlies

### DIFF
--- a/.hhconfig
+++ b/.hhconfig
@@ -9,4 +9,4 @@ disallow_stringish_magic = true
 user_attributes=
 error_php_lambdas = true
 allowed_decl_fixme_codes=2053,4045
-allowed_fixme_codes_strict=2011,2049,2050,2053,4027,4045,4107,4108,4110,4128,4135,4188,4240,4323
+allowed_fixme_codes_strict=2011,2049,2050,2053,4027,4045,4106,4107,4108,4110,4128,4135,4188,4240,4323

--- a/.hhconfig
+++ b/.hhconfig
@@ -9,4 +9,4 @@ disallow_stringish_magic = true
 user_attributes=
 error_php_lambdas = true
 allowed_decl_fixme_codes=2053,4045
-allowed_fixme_codes_strict=2011,2049,2050,2053,4027,4045,4106,4108,4110,4128,4135,4188,4240,4323
+allowed_fixme_codes_strict=2011,2049,2050,2053,4027,4045,4107,4108,4110,4128,4135,4188,4240,4323

--- a/.hhconfig
+++ b/.hhconfig
@@ -8,3 +8,5 @@ disallow_invalid_arraykey = true
 disallow_stringish_magic = true
 user_attributes=
 error_php_lambdas = true
+allowed_decl_fixme_codes=2053,4045
+allowed_fixme_codes_strict=2011,2049,2050,2053,4027,4045,4106,4108,4110,4128,4135,4188,4240,4323

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ sudo: required
 language: generic
 services: docker
 env:
-- HHVM_VERSION=4.30-latest
-- HHVM_VERSION=4.32-latest
+- HHVM_VERSION=4.56-latest
 - HHVM_VERSION=latest
 - HHVM_VERSION=nightly
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 language: generic
 services: docker
 env:
-- HHVM_VERSION=4.56-latest
+- HHVM_VERSION=4.60-latest
 - HHVM_VERSION=latest
 - HHVM_VERSION=nightly
 install:

--- a/composer.json
+++ b/composer.json
@@ -2,9 +2,9 @@
   "name": "hhvm/type-assert",
   "description": "Convert untyped data to typed data",
   "license": "MIT",
-  "keywords": ["hack", "TypeAssert" ],
+  "keywords": ["hack", "TypeAssert"],
   "require": {
-    "hhvm": "^4.30",
+    "hhvm": "^4.56",
     "hhvm/hsl": "^4.0"
   },
   "extra": {

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "keywords": ["hack", "TypeAssert"],
   "require": {
-    "hhvm": "^4.56",
+    "hhvm": "^4.60",
     "hhvm/hsl": "^4.0"
   },
   "extra": {

--- a/src/TypeSpec.hack
+++ b/src/TypeSpec.hack
@@ -151,11 +151,6 @@ function string(): TypeSpec<string> {
   return new __Private\StringSpec();
 }
 
-/* HH_IGNORE_ERROR[4045] untyped array */
-function untyped_array(): TypeSpec<array> {
-  return new __Private\UntypedArraySpec();
-}
-
 function varray<Tv>(TypeSpec<Tv> $tsv): TypeSpec<varray<Tv>> {
   return new __Private\VarraySpec($tsv);
 }

--- a/src/TypeSpec/__Private/DarraySpec.hack
+++ b/src/TypeSpec/__Private/DarraySpec.hack
@@ -46,7 +46,7 @@ final class DarraySpec<Tk as arraykey, Tv>
 
   <<__Override>>
   public function assertType(mixed $value): darray<Tk, Tv> {
-    if (!\is_array($value)) {
+    if (/* HH_FIXME[2049] */ /* HH_FIXME[4107] */ !is_darray($value)) {
       throw IncorrectTypeException::withValue(
         $this->getTrace(),
         $this->toString(),
@@ -58,7 +58,7 @@ final class DarraySpec<Tk as arraykey, Tv>
     $vt = $this->getTrace()->withFrame('darray<_, Tv>');
 
     return Dict\pull_with_key(
-      $value,
+      $value as KeyedTraversable<_, _>,
       ($_k, $v) ==> $this->tsv->withTrace($vt)->assertType($v),
       ($k, $_v) ==> $this->tsk->withTrace($kt)->assertType($k),
     )

--- a/src/TypeSpec/__Private/UnionSpec.hack
+++ b/src/TypeSpec/__Private/UnionSpec.hack
@@ -20,7 +20,7 @@ abstract class UnionSpec<+T> extends TypeSpec<T> {
   }
 
   <<__Override>>
-  final public function coerceType(mixed $value): T {
+  public function coerceType(mixed $value): T {
     try {
       return $this->assertType($value);
     } catch (IncorrectTypeException $_) {

--- a/src/TypeSpec/__Private/VArrayOrDArraySpec.hack
+++ b/src/TypeSpec/__Private/VArrayOrDArraySpec.hack
@@ -39,11 +39,11 @@ final class VArrayOrDArraySpec<T> extends UnionSpec<varray_or_darray<T>> {
     } catch (\Throwable $_) {
     }
 
-    if ($value is vec<_> || $value is Vector<_> || $value is ImmVector<_> ) {
+    if ($value is vec<_> || $value is ConstVector<_>) {
       return $this->varraySpec->coerceType($value);
     }
 
-    if ($value is dict<_, _> || $value is Map<_, _> || $value is ImmMap<_, _>) {
+    if ($value is dict<_, _> || $value is ConstMap<_, _>) {
       return $this->darraySpec->coerceType($value);
     }
 

--- a/src/TypeSpec/__Private/VArrayOrDArraySpec.hack
+++ b/src/TypeSpec/__Private/VArrayOrDArraySpec.hack
@@ -39,11 +39,11 @@ final class VArrayOrDArraySpec<T> extends UnionSpec<varray_or_darray<T>> {
     } catch (\Throwable $_) {
     }
 
-    if ($value is vec<_> || $value is ConstVector<_>) {
+    if ($value is vec<_> || $value is /* HH_FIXME[2049] */ ConstVector<_>) {
       return $this->varraySpec->coerceType($value);
     }
 
-    if ($value is dict<_, _> || $value is ConstMap<_, _>) {
+    if ($value is dict<_, _> || $value is /* HH_FIXME[2049] */ ConstMap<_, _>) {
       return $this->darraySpec->coerceType($value);
     }
 

--- a/src/TypeSpec/__Private/VarraySpec.hack
+++ b/src/TypeSpec/__Private/VarraySpec.hack
@@ -31,12 +31,12 @@ final class VarraySpec<T> extends TypeSpec<varray<T>> {
     }
 
     return Vec\map($value, $inner ==> $this->inner->coerceType($inner))
-      |> \array_values($$);
+      |> varray($$);
   }
 
   <<__Override>>
   public function assertType(mixed $value): varray<T> {
-    if (!\is_array($value)) {
+    if (/* HH_FIXME[2049] */ /* HH_FIXME[4107] */ !is_varray($value)) {
       throw IncorrectTypeException::withValue(
         $this->getTrace(),
         'varray<T>',
@@ -53,7 +53,7 @@ final class VarraySpec<T> extends TypeSpec<varray<T>> {
     )();
 
     return Vec\map_with_key(
-      $value,
+      $value as KeyedTraversable<_, _>,
       ($k, $inner) ==> {
         $counter->next();
         $i = $counter->current();

--- a/src/TypeSpec/__Private/from_type_structure.hack
+++ b/src/TypeSpec/__Private/from_type_structure.hack
@@ -68,23 +68,7 @@ function from_type_structure<T>(TypeStructure<T> $ts): TypeSpec<T> {
     case TypeStructureKind::OF_FUNCTION:
       throw new UnsupportedTypeException('OF_FUNCTION');
     case TypeStructureKind::OF_ARRAY:
-      $generics = $ts['generic_types'] ?? vec[];
-      switch (C\count($generics)) {
-        case 0:
-          /* HH_IGNORE_ERROR[4110] */
-          return new UntypedArraySpec();
-        case 1:
-          /* HH_IGNORE_ERROR[4110] */
-          return new VarraySpec(from_type_structure($generics[0]));
-        case 2:
-          /* HH_IGNORE_ERROR[4110] */
-          return new DarraySpec(
-            from_type_structure($generics[0]),
-            from_type_structure($generics[1]),
-          );
-        default:
-          invariant_violation('OF_ARRAY with > 2 generics');
-      }
+      throw new UnsupportedTypeException('OF_ARRAY');
     case TypeStructureKind::OF_VARRAY:
       $generics = $ts['generic_types'] as nonnull;
       invariant(C\count($generics) === 1, 'got varray with multiple generics');

--- a/tests/TypeStructureTest.hack
+++ b/tests/TypeStructureTest.hack
@@ -36,29 +36,9 @@ final class TypeStructureTest extends \Facebook\HackTest\HackTest {
         type_structure(TypeConstants::class, 'TTuple'),
         tuple('foo', 123),
       ),
-      'empty array<string>' => tuple(
-        type_structure(TypeConstants::class, 'TStringArray'),
-        /* HHAST_IGNORE_ERROR[NoPHPArrayLiterals] */
-        array(),
-      ),
-      'array<string>' => tuple(
-        type_structure(TypeConstants::class, 'TStringArray'),
-        /* HHAST_IGNORE_ERROR[NoPHPArrayLiterals] */
-        array('123', '456'),
-      ),
       'varray<string>' => tuple(
         type_structure(TypeConstants::class, 'TStringVArray'),
         varray['123', '456'],
-      ),
-      'empty array<string, string>' => tuple(
-        type_structure(TypeConstants::class, 'TStringStringArray'),
-        /* HHAST_IGNORE_ERROR[NoPHPArrayLiterals] */
-        array(),
-      ),
-      'array<string, string>' => tuple(
-        type_structure(TypeConstants::class, 'TStringStringArray'),
-        /* HHAST_IGNORE_ERROR[NoPHPArrayLiterals] */
-        array('foo' => 'bar', 'herp' => 'derp'),
       ),
       'darray<string, string>' => tuple(
         type_structure(TypeConstants::class, 'TStringStringDArray'),
@@ -164,13 +144,11 @@ final class TypeStructureTest extends \Facebook\HackTest\HackTest {
       ),
       'shape with empty container' => tuple(
         type_structure(TypeConstants::class, 'TShapeWithContainer'),
-        /* HHAST_IGNORE_ERROR[NoPHPArrayLiterals] */
-        array('container' => Vector {}),
+        darray['container' => Vector {}],
       ),
       'shape with non-empty container' => tuple(
         type_structure(TypeConstants::class, 'TShapeWithContainer'),
-        /* HHAST_IGNORE_ERROR[NoPHPArrayLiterals] */
-        array('container' => Vector {'foo'}),
+        darray['container' => Vector {'foo'}],
       ),
       'enum' =>
         tuple(type_structure(TypeConstants::class, 'TEnum'), ExampleEnum::DERP),
@@ -202,21 +180,6 @@ final class TypeStructureTest extends \Facebook\HackTest\HackTest {
         type_structure(TypeConstants::class, 'TStringKeyset'),
         keyset['foo', 'bar', 'baz', 'herp', 'derp'],
       ),
-      'empty array as array<>' => tuple(
-        type_structure(TypeConstants::class, 'TArrayWithoutGenerics'),
-        /* HHAST_IGNORE_ERROR[NoPHPArrayLiterals] */
-        array(),
-      ),
-      'vec-like array as array<>' => tuple(
-        type_structure(TypeConstants::class, 'TArrayWithoutGenerics'),
-        /* HHAST_IGNORE_ERROR[NoPHPArrayLiterals] */
-        array('foo', 'bar'),
-      ),
-      'dict-like array as array<>' => tuple(
-        type_structure(TypeConstants::class, 'TArrayWithoutGenerics'),
-        /* HHAST_IGNORE_ERROR[NoPHPArrayLiterals] */
-        array('foo' => 'bar'),
-      ),
       'varray<int> as varray_or_darray<int>' => tuple(
         type_structure(TypeConstants::class, 'TVArrayOrDArray'),
         varray[123],
@@ -224,29 +187,6 @@ final class TypeStructureTest extends \Facebook\HackTest\HackTest {
       'darray<int> as varray_or_darray<int>' => tuple(
         type_structure(TypeConstants::class, 'TVArrayOrDArray'),
         darray['foo' => 123],
-      ),
-      'empty array in array<> shape field' => tuple(
-        type_structure(TypeConstants::class, 'TShapeWithArrayWithoutGenerics'),
-        shape(
-          'one' => true,
-          'two' => /* HHAST_IGNORE_ERROR[NoPHPArrayLiterals] */ array(),
-        ),
-      ),
-      'vec-like array in array<> shape field' => tuple(
-        type_structure(TypeConstants::class, 'TShapeWithArrayWithoutGenerics'),
-        shape(
-          'one' => true,
-          'two' =>
-            /* HHAST_IGNORE_ERROR[NoPHPArrayLiterals] */ array('foo', 'bar'),
-        ),
-      ),
-      'dict-like array in array<> shape field' => tuple(
-        type_structure(TypeConstants::class, 'TShapeWithArrayWithoutGenerics'),
-        shape(
-          'one' => true,
-          'two' =>
-            /* HHAST_IGNORE_ERROR[NoPHPArrayLiterals] */ array('foo' => 'bar'),
-        ),
       ),
     ];
   }
@@ -292,24 +232,6 @@ final class TypeStructureTest extends \Facebook\HackTest\HackTest {
         type_structure(TypeConstants::class, 'TTuple'),
         tuple('foo', 123, 456),
         vec[],
-      ),
-      'int in array<string>' => tuple(
-        type_structure(TypeConstants::class, 'TStringArray'),
-        /* HHAST_IGNORE_ERROR[NoPHPArrayLiterals] */
-        array(123),
-        vec['varray[0]'],
-      ),
-      'int keys in array<string, string>' => tuple(
-        type_structure(TypeConstants::class, 'TStringStringArray'),
-        /* HHAST_IGNORE_ERROR[NoPHPArrayLiterals] */
-        array(123 => 'bar', 123 => 'derp'),
-        vec['darray<Tk, _>'],
-      ),
-      'int values in array<string, string>' => tuple(
-        type_structure(TypeConstants::class, 'TStringStringArray'),
-        /* HHAST_IGNORE_ERROR[NoPHPArrayLiterals] */
-        array('foo' => 123, 'bar' => 456),
-        vec['darray<_, Tv>'],
       ),
       '0 as ?string' => tuple(
         type_structure(TypeConstants::class, 'TNullableString'),
@@ -508,11 +430,10 @@ final class TypeStructureTest extends \Facebook\HackTest\HackTest {
     );
   }
 
+  const type TUnsupported = array<string>;
   public function testUnsupportedType(): void {
-    $ts = type_structure(TypeConstants::class, 'TStringArray');
-    $ts['kind'] = TypeStructureKind::OF_GENERIC;
+    $ts = type_structure(self::class, 'TUnsupported');
 
-    /* HH_IGNORE_ERROR[4110] */
     expect(() ==> TypeAssert\matches_type_structure($ts, null))->toThrow(
       UnsupportedTypeException::class,
     );

--- a/tests/VArrayOrDArraySpecTest.hack
+++ b/tests/VArrayOrDArraySpecTest.hack
@@ -25,6 +25,8 @@ final class VArrayOrDArraySpecTest
   public function getValidCoercions(): vec<(mixed, varray_or_darray<int>)> {
     return vec[
       tuple(vec[], varray[]),
+      tuple(dict[], darray[]),
+      tuple(keyset[], darray[]),
       tuple(vec['123'], varray[123]),
       tuple(varray['123'], varray[123]),
       tuple(varray[123], varray[123]),

--- a/tests/VArrayOrDArraySpecTest.hack
+++ b/tests/VArrayOrDArraySpecTest.hack
@@ -32,6 +32,7 @@ final class VArrayOrDArraySpecTest
       tuple(varray[123], varray[123]),
       tuple(dict['foo' => '456'], darray['foo' => 456]),
       tuple(Vector {123}, varray[123]),
+      tuple(Pair {123, 456}, varray[123, 456]),
       tuple(darray['foo' => 123], darray['foo' => 123]),
       tuple(keyset['123'], darray['123' => 123]),
     ];

--- a/tests/fixtures/TypeConstants.hack
+++ b/tests/fixtures/TypeConstants.hack
@@ -18,9 +18,7 @@ class TypeConstants {
   const type TNum = num;
   const type TArrayKey = arraykey;
   const type TTuple = (string, int);
-  const type TStringArray = array<string>;
   const type TStringVArray = varray<string>;
-  const type TStringStringArray = array<string, string>;
   const type TStringStringDArray = darray<string, string>;
 
   const type TNullableString = ?string;
@@ -66,12 +64,5 @@ class TypeConstants {
   const type TStringStringVecDict = dict<string, vec<string>>;
   const type TStringKeyset = keyset<string>;
 
-  /* HH_IGNORE_ERROR[4045] array without generics */
-  const type TArrayWithoutGenerics = array;
-  const type TShapeWithArrayWithoutGenerics = shape(
-    'one' => bool,
-    /* HH_IGNORE_ERROR[4045] array without generics */
-    'two' => array,
-  );
   const type TVArrayOrDArray = varray_or_darray<int>;
 }


### PR DESCRIPTION
replaces #52  by @lexidor

- add fixme whitelists
- removes PHP array support
- makes VarrayOrDarraySpec try harder to figure out if it should use a varray, now that they're even less interchangeable