### PR TITLE
fix EnumSpec upper-bound-enforcement issues

### DIFF
--- a/src/TypeSpec.hack
+++ b/src/TypeSpec.hack
@@ -73,10 +73,7 @@ function dict<Tk as arraykey, Tv>(
   return new __Private\DictSpec($tsk, $tsv);
 }
 
-function enum<
-  Tinner as arraykey,
-  T as /* HH_IGNORE_ERROR[2053] */ \HH\BuiltinEnum<Tinner>,
->(classname<T> $what): TypeSpec<T> {
+function enum<T as arraykey>(\HH\enumname<T> $what): TypeSpec<T> {
   return new __Private\EnumSpec($what);
 }
 

--- a/src/TypeSpec/__Private/EnumSpec.hack
+++ b/src/TypeSpec/__Private/EnumSpec.hack
@@ -13,19 +13,15 @@ namespace Facebook\TypeSpec\__Private;
 use type Facebook\TypeAssert\{IncorrectTypeException, TypeCoercionException};
 use type Facebook\TypeSpec\TypeSpec;
 
-final class
-  EnumSpec<
-    Tinner as arraykey,
-    T as /* HH_IGNORE_ERROR[2053] */ \HH\BuiltinEnum<Tinner>,
-  > extends TypeSpec<T> {
-  public function __construct(private classname<T> $what) {
+final class EnumSpec<T as arraykey> extends TypeSpec<T> {
+
+  public function __construct(private \HH\enumname<T> $what) {
   }
 
   <<__Override>>
   public function coerceType(mixed $value): T {
     $what = $this->what;
     try {
-      /* HH_IGNORE_ERROR[4110] */
       return $what::assert($value);
     } catch (\UnexpectedValueException $_e) {
       throw TypeCoercionException::withValue($this->getTrace(), $what, $value);
@@ -36,7 +32,6 @@ final class
   public function assertType(mixed $value): T {
     $what = $this->what;
     try {
-      /* HH_IGNORE_ERROR[4110] */
       return $what::assert($value);
     } catch (\UnexpectedValueException $_e) {
       throw IncorrectTypeException::withValue($this->getTrace(), $what, $value);

--- a/src/TypeSpec/__Private/from_type_structure.hack
+++ b/src/TypeSpec/__Private/from_type_structure.hack
@@ -195,7 +195,7 @@ function from_type_structure<T>(TypeStructure<T> $ts): TypeSpec<T> {
       throw new UnsupportedTypeException('OF_TRAIT');
     case TypeStructureKind::OF_ENUM:
       $enum = TypeAssert\not_null($ts['classname']);
-      /* HH_IGNORE_ERROR[4323] */
+      /* HH_IGNORE_ERROR[4110] */
       return new EnumSpec($enum);
     case TypeStructureKind::OF_NULL:
       /* HH_IGNORE_ERROR[4110] unsafe generics */

--- a/tests/EnumSpecTest.hack
+++ b/tests/EnumSpecTest.hack
@@ -1,0 +1,67 @@
+/*
+ *  Copyright (c) 2016, Fred Emmott
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\TypeAssert;
+
+use namespace Facebook\{TypeAssert, TypeSpec};
+use type Facebook\TypeAssert\TestFixtures\{ExampleEnum, TypeConstants};
+use type Facebook\TypeSpec\TypeSpec;
+use function Facebook\FBExpect\expect;
+
+final class EnumSpecTest extends TypeSpecTest<ExampleEnum> {
+  <<__Override>>
+  public function getTypeSpec(): TypeSpec<ExampleEnum> {
+    return TypeSpec\enum(ExampleEnum::class);
+  }
+
+  <<__Override>>
+  public function getValidCoercions(): vec<(mixed, ExampleEnum)> {
+    return vec[
+      tuple('herp', ExampleEnum::HERP),
+      tuple(ExampleEnum::DERP, ExampleEnum::DERP),
+    ];
+  }
+
+  <<__Override>>
+  public function getInvalidCoercions(): vec<(mixed)> {
+    return vec[
+      tuple('analbumcover'),
+      tuple(42),
+    ];
+  }
+
+  <<__Override>>
+  public function getToStringExamples(): vec<(TypeSpec<ExampleEnum>, string)> {
+    $spec = TypeSpec\enum(ExampleEnum::class);
+    return vec[
+      tuple($spec, ExampleEnum::class),
+      tuple($spec, 'Facebook\\TypeAssert\\TestFixtures\\ExampleEnum'),
+    ];
+  }
+
+  /**
+   * In this test we mostly care that all these possible ways of coercing an
+   * enum value are accepted by the typechecker. They should also not cause
+   * runtime errors, but that's already covered by other tests.
+   */
+  public function testTypechecks(): void {
+    self::takesEnum(TypeSpec\of<ExampleEnum>()->assertType('herp'));
+    self::takesEnum(TypeSpec\enum(ExampleEnum::class)->assertType('herp'));
+    self::takesEnum(TypeAssert\matches<ExampleEnum>('herp'));
+    self::takesEnum(TypeAssert\matches_type_structure(
+      type_structure(TypeConstants::class, 'TEnum'),
+      'herp',
+    ));
+  }
+
+  private static function takesEnum(ExampleEnum $value): void {
+    expect($value is ExampleEnum)->toBeTrue();
+  }
+}

--- a/tests/TypeStructureTest.hack
+++ b/tests/TypeStructureTest.hack
@@ -426,7 +426,7 @@ final class TypeStructureTest extends \Facebook\HackTest\HackTest {
     );
   }
 
-  const type TUnsupported = array<string>;
+  const type TUnsupported = (function(): void);
   public function testUnsupportedType(): void {
     $ts = type_structure(self::class, 'TUnsupported');
 


### PR DESCRIPTION
`\HH\BuiltinEnum` is not a real type (honestly I'm not sure what it is), so this started failing once HHVM started enforcing upper bounds on generic arguments/return values.

I'm not sure if this is 100% correct now (or if it was before), but I added some tests to verify that the return value from `$enumspec->assert(...)` still passes enum typehints, which is probably the important part.