### PR TITLE
Prepare to remove implicit coercion from assert paths

### DIFF
--- a/src/TypeSpec/__Private/TupleSpec.hack
+++ b/src/TypeSpec/__Private/TupleSpec.hack
@@ -22,9 +22,12 @@ final class TupleSpec extends TypeSpec<BogusTuple> {
 
   <<__Override>>
   public function coerceType(mixed $value): BogusTuple {
-    if (!\HH\is_vec_or_varray($value)) {
-      throw
-        TypeCoercionException::withValue($this->getTrace(), 'tuple', $value);
+    if (!$value is vec<_>) {
+      throw TypeCoercionException::withValue(
+        $this->getTrace(),
+        'tuple',
+        $value,
+      );
     }
     $values = vec($value);
 
@@ -43,16 +46,17 @@ final class TupleSpec extends TypeSpec<BogusTuple> {
         ->withTrace($this->getTrace()->withFrame('tuple['.$i.']'))
         ->coerceType($values[$i]);
     }
-    return self::vecToTuple($out);
+    return self::vecToTupleUNSAFE($out);
   }
 
   <<__Override>>
   public function assertType(mixed $value): BogusTuple {
-    if (\HH\is_vec_or_varray($value)) {
-      $value = vec($value);
-    } else if (!($value is vec<_>)) {
-      throw
-        IncorrectTypeException::withValue($this->getTrace(), 'tuple', $value);
+    if (!$value is vec<_>) {
+      throw IncorrectTypeException::withValue(
+        $this->getTrace(),
+        'tuple',
+        $value,
+      );
     }
     $values = $value;
 
@@ -71,16 +75,12 @@ final class TupleSpec extends TypeSpec<BogusTuple> {
         ->withTrace($this->getTrace()->withFrame('tuple['.$i.']'))
         ->assertType($values[$i]);
     }
-    return self::vecToTuple($out);
+    return self::vecToTupleUNSAFE($out);
   }
 
-  private static function vecToTuple(vec<mixed> $tuple): BogusTuple {
-    if (tuple('foo') is vec<_>) {
-      /* HH_IGNORE_ERROR[4110] */
-      return $tuple;
-    }
-    /* HH_IGNORE_ERROR[4110] */
-    return varray($tuple);
+  private static function vecToTupleUNSAFE(vec<mixed> $tuple): BogusTuple {
+    /* HH_IGNORE_ERROR[4110] Depends on runtime representation of tuple being vec */
+    return $tuple;
   }
 
   <<__Override>>

--- a/src/TypeSpec/__Private/stringish_cast.hack
+++ b/src/TypeSpec/__Private/stringish_cast.hack
@@ -11,14 +11,7 @@ namespace Facebook\TypeSpec\__Private;
 function stringish_cast(\Stringish $stringish, string $caller): string {
   if ($stringish is string) {
     return $stringish;
-  } else if (\HH\is_fun($stringish)) {
-    return \HH\fun_get_function($stringish);
-  } else {
-    invariant(
-      $stringish is \StringishObject,
-      'Expected Stringish to be either a string or a StringishObject, got %s',
-      \get_class($stringish) ?: \gettype($stringish),
-    );
+  } else if ($stringish is \StringishObject) {
     \trigger_error(
       'Stringish is being deprecated. '.
       'Passing an object that implements __toString to '.
@@ -26,7 +19,10 @@ function stringish_cast(\Stringish $stringish, string $caller): string {
       '() may not work in a future release.',
       \E_USER_DEPRECATED,
     );
-    /*HH_FIXME[4128] stringish_cast() can't be used in the future.*/
     return $stringish->__toString();
+  } else {
+    invariant_violation(
+      'Unknown Stringish subtype, expected string|StringishObject.',
+    );
   }
 }

--- a/tests/EnumCoercionInAssertPathTest.hack
+++ b/tests/EnumCoercionInAssertPathTest.hack
@@ -16,14 +16,14 @@ use type Facebook\HackTest\HackTest;
 use function Facebook\FBExpect\expect;
 
 final class EnumCoercionInAssertPathTest extends HackTest {
-  public function test_coercion_does_warn(): void {
+  public function testCoercionDoesWarn(): void {
     expect(() ==> TypeAssert\matches<IntegralKeyCoercionEnum>('3'))
       ->toTriggerAnError(\E_USER_DEPRECATED, 'does contain the int value 3');
     expect(() ==> TypeAssert\matches<IntegralKeyCoercionEnum>(2))
       ->toTriggerAnError(\E_USER_DEPRECATED, 'does contain the string value 2');
   }
 
-  public function test_coersion_does_not_warn_if_both_int_and_string_exist(
+  public function testCoersionDoesNotWarnIfBothIntAndStringExist(
   ): void {
     try {
       \set_error_handler(() ==> {

--- a/tests/EnumCoercionInAssertPathTest.hack
+++ b/tests/EnumCoercionInAssertPathTest.hack
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (c) 2016, Fred Emmott
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\TypeAssert;
+
+use namespace Facebook\TypeAssert;
+use type Facebook\TypeAssert\TestFixtures\IntegralKeyCoercionEnum;
+use type Facebook\HackTest\HackTest;
+use function Facebook\FBExpect\expect;
+
+final class EnumCoercionInAssertPathTest extends HackTest {
+  public function test_coercion_does_warn(): void {
+    expect(() ==> TypeAssert\matches<IntegralKeyCoercionEnum>('3'))
+      ->toTriggerAnError(\E_USER_DEPRECATED, 'does contain the int value 3');
+    expect(() ==> TypeAssert\matches<IntegralKeyCoercionEnum>(2))
+      ->toTriggerAnError(\E_USER_DEPRECATED, 'does contain the string value 2');
+  }
+
+  public function test_coersion_does_not_warn_if_both_int_and_string_exist(
+  ): void {
+    try {
+      \set_error_handler(() ==> {
+        throw new \LogicException('No error expected');
+      });
+      TypeAssert\matches<IntegralKeyCoercionEnum>(1);
+    } finally {
+      \set_error_handler(null);
+    }
+  }
+}

--- a/tests/fixtures/IntegralKeyCoersionEnum.hack
+++ b/tests/fixtures/IntegralKeyCoersionEnum.hack
@@ -1,0 +1,20 @@
+/*
+ *  Copyright (c) 2016, Fred Emmott
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\TypeAssert\TestFixtures;
+
+enum IntegralKeyCoercionEnum: arraykey {
+  ONE_STR = '1';
+  ONE_INT = 1;
+  TWO_STR = '2';
+  THREE_INT = 3;
+  DUPLICATE_VALUE_4 = 4;
+  ANOTHER_VALUE_4 = 4;
+}

--- a/tests/fixtures/TypeConstants.hack
+++ b/tests/fixtures/TypeConstants.hack
@@ -32,7 +32,6 @@ class TypeConstants {
   const type TStringIntKeyedTraversable = KeyedTraversable<string, int>;
   const type TStringIntKeyedContainer = KeyedContainer<string, int>;
 
-  /* HH_FIXME[3033] no optional shape fields in 3.21 or 3.22 */
   const type TFlatShape = shape(
     'someString' => string,
     'someNullable' => ?string,
@@ -44,7 +43,6 @@ class TypeConstants {
     'someString' => string,
   );
 
-  /* HH_FIXME[0003] no unknown shape fields in 3.21 */
   const type TShapeWithOneFieldAndImplicitSubtypes = shape(
     'someString' => string,
     ...


### PR DESCRIPTION
 - `Enum::assert()` does keyish coercion, so `3` and `"3"` are both valid member of the enum. This commit adds a deprecation notice for this behavior.
 - `ShapeSpec` and `TupleSpec` do not need to test the type of `shape()` and `tuple()`. This is consistently a Hack array in all supported versions.
 - Removed `HH\fun` support from `stringish_cast()`. This never actually did anything, since native function references to not implement `\Stringish`, which was the type of the parameter. This was essentially dead code.