### PR TITLE
Fix some lints reported by CI on HHVM latest

### DIFF
--- a/src/TypeSpec/__Private/from_type_structure.hack
+++ b/src/TypeSpec/__Private/from_type_structure.hack
@@ -63,7 +63,7 @@ function from_type_structure<T>(TypeStructure<T> $ts): TypeSpec<T> {
       return new TupleSpec(
         Vec\map(
           TypeAssert\not_null($ts['elem_types']),
-          $elem ==> from_type_structure($elem),
+          from_type_structure<>,
         ),
       );
     case TypeStructureKind::OF_FUNCTION:

--- a/tests/ScalarsTest.hack
+++ b/tests/ScalarsTest.hack
@@ -117,15 +117,14 @@ final class ScalarsTest extends \Facebook\HackTest\HackTest {
   public function getExampleValidCoercions(
   ): dict<string, ((function(mixed): mixed), mixed, mixed)> {
     return dict[
-      'int to string' => tuple($x ==> TypeCoerce\string($x), 123, '123'),
-      'intish string to int' => tuple($x ==> TypeCoerce\int($x), '123', 123),
-      'intish string to num' => tuple($x ==> TypeCoerce\num($x), '123', 123),
-      'decimal string to num' => tuple($x ==> TypeCoerce\num($x), '1.23', 1.23),
-      'int to arraykey' => tuple($x ==> TypeCoerce\arraykey($x), 123, 123),
-      'string to arraykey' =>
-        tuple($x ==> TypeCoerce\arraykey($x), '123', '123'),
+      'int to string' => tuple(TypeCoerce\string<>, 123, '123'),
+      'intish string to int' => tuple(TypeCoerce\int<>, '123', 123),
+      'intish string to num' => tuple(TypeCoerce\num<>, '123', 123),
+      'decimal string to num' => tuple(TypeCoerce\num<>, '1.23', 1.23),
+      'int to arraykey' => tuple(TypeCoerce\arraykey<>, 123, 123),
+      'string to arraykey' => tuple(TypeCoerce\arraykey<>, '123', '123'),
       'stringable to arraykey' =>
-        tuple($x ==> TypeCoerce\arraykey($x), new TestStringable('123'), '123'),
+        tuple(TypeCoerce\arraykey<>, new TestStringable('123'), '123'),
     ];
   }
 


### PR DESCRIPTION
Our CI was reporting a number of "You have made a lambda which forwards all its arguments to a static method or function." lints on HHVM latest. Apply the changes suggested by the linter.