### PR TITLE
Fix bugs in collection specs

### DIFF
--- a/.hhvmconfig.hdf
+++ b/.hhvmconfig.hdf
@@ -1,0 +1,3 @@
+Autoload {
+  Query = {"expression": ["allof", ["type", "f"], ["suffix", ["anyof", "hack", "php"]], ["not",["anyof",["dirname",".var"],["dirname",".git"]]]]}
+}

--- a/.hhvmconfig.hdf
+++ b/.hhvmconfig.hdf
@@ -1,3 +1,0 @@
-Autoload {
-  Query = {"expression": ["allof", ["type", "f"], ["suffix", ["anyof", "hack", "php"]], ["not",["anyof",["dirname",".var"],["dirname",".git"]]]]}
-}

--- a/src/TypeSpec/__Private/MapSpec.hack
+++ b/src/TypeSpec/__Private/MapSpec.hack
@@ -12,7 +12,7 @@ namespace Facebook\TypeSpec\__Private;
 
 use type Facebook\TypeAssert\{IncorrectTypeException, TypeCoercionException};
 use type Facebook\TypeSpec\TypeSpec;
-use namespace HH\Lib\{C, Dict, Str};
+use namespace HH\Lib\{C, Str};
 
 final class MapSpec<Tk as arraykey, Tv, T as \ConstMap<Tk, Tv>>
   extends TypeSpec<T> {
@@ -109,7 +109,7 @@ final class MapSpec<Tk as arraykey, Tv, T as \ConstMap<Tk, Tv>>
       return $out;
     }
 
-    /* HH_IGNORE_ERROR[4110] Return ImmMap when the user asks for ConstMap or ImmMap. 
+    /* HH_IGNORE_ERROR[4110] Return ImmMap when the user asks for ConstMap or ImmMap.
        This immutability for ConstMap is not needed, but kept for backwards compatibility. */
     return $out->immutable();
   }

--- a/src/TypeSpec/__Private/SetSpec.hack
+++ b/src/TypeSpec/__Private/SetSpec.hack
@@ -95,7 +95,7 @@ final class SetSpec<Tv as arraykey, T as \ConstSet<Tv>> extends TypeSpec<T> {
       return $out;
     }
 
-    /* HH_IGNORE_ERROR[4110] Return ImmSet when the user asks for ConstSet or ImmSet. 
+    /* HH_IGNORE_ERROR[4110] Return ImmSet when the user asks for ConstSet or ImmSet.
        This immutability for ConstSet is not needed, but kept for consistency with MapSpec and VectorSpec. */
     return $out->immutable();
   }

--- a/src/TypeSpec/__Private/VectorSpec.hack
+++ b/src/TypeSpec/__Private/VectorSpec.hack
@@ -94,7 +94,7 @@ final class VectorSpec<Tv, T as \ConstVector<Tv>> extends TypeSpec<T> {
       return $out;
     }
 
-    /* HH_IGNORE_ERROR[4110] Return ImmVector when the user asks for ConstVector or ImmVector. 
+    /* HH_IGNORE_ERROR[4110] Return ImmVector when the user asks for ConstVector or ImmVector.
        This immutability for ConstVector is not needed, but kept for backwards compatibility. */
     return $out->immutable();
   }

--- a/tests/CollectionSpecOdditiesTest.hack
+++ b/tests/CollectionSpecOdditiesTest.hack
@@ -10,9 +10,7 @@
 
 namespace Facebook\TypeAssert;
 
-use namespace Facebook\TypeSpec;
 use type Facebook\HackTest\HackTest;
-use type Facebook\TypeSpec\TypeSpec;
 use type Facebook\TypeAssert\TestFixtures\IntishStringEnum;
 use function Facebook\FBExpect\expect;
 

--- a/tests/CollectionSpecOdditiesTest.hack
+++ b/tests/CollectionSpecOdditiesTest.hack
@@ -17,16 +17,57 @@ use type Facebook\TypeAssert\TestFixtures\IntishStringEnum;
 use function Facebook\FBExpect\expect;
 
 final class CollectionSpecOdditiesTest extends HackTest {
-  public function testContainerSpecsDisregardInnerSpecAndReturnTheIdenticalObject(
-  ): void {
+  public function testContainerSpecsHonorInnerSpecAndReturnANewObject(): void {
     $set = Set {1};
-    expect(matches<\ConstSet<IntishStringEnum>>($set))->toEqual($set);
+    $copy_set = new Set($set);
+    expect(matches<\ConstSet<IntishStringEnum>>($set))->toHaveSameContentAs(
+      ImmSet {IntishStringEnum::ONE},
+    );
+    expect($set)->toHaveSameContentAs($copy_set, 'to be unchanged');
 
     $map = Map {1 => 1};
-    expect(matches<\ConstMap<IntishStringEnum, int>>($map))->toEqual($map);
-    expect(matches<\ConstMap<int, IntishStringEnum>>($map))->toEqual($map);
+    $copy_map = new Map($map);
+    expect(matches<\ConstMap<IntishStringEnum, int>>($map))
+      ->toHaveSameContentAs(ImmMap {IntishStringEnum::ONE => 1});
+    expect(matches<\ConstMap<int, IntishStringEnum>>($map))
+      ->toHaveSameContentAs(ImmMap {1 => IntishStringEnum::ONE});
+    expect($map)->toHaveSameShapeAs($copy_map, 'to be unchanged');
 
     $vector = Vector {1};
-    expect(matches<\ConstVector<IntishStringEnum>>($vector))->toEqual($vector);
+    $copy_vector = new Vector($vector);
+    expect(matches<\ConstVector<IntishStringEnum>>($vector))
+      ->toHaveSameContentAs(ImmVector {IntishStringEnum::ONE});
+    expect($vector)->toHaveSameContentAs($copy_vector, 'to be unchanged');
+  }
+
+  public function testWhenNoChangesConstXXXDoesNotPromoteToImm(): void {
+    $set = Set {1};
+    expect(matches<\ConstSet<int>>($set))->toEqual($set);
+
+    $map = Map {1 => 1};
+    expect(matches<\ConstMap<int, int>>($map))->toEqual($map);
+
+    $vector = Vector {1};
+    expect(matches<\ConstVector<int>>($vector))->toEqual($vector);
+  }
+
+  public function testWhenChangeesConstXXXDoesPromoteToImm(): void {
+    $set = Set {1};
+    expect(matches<\ConstSet<IntishStringEnum>>($set))->toBeInstanceOf(
+      ImmSet::class,
+    );
+
+    $map = Map {1 => 1};
+    expect(matches<\ConstMap<IntishStringEnum, int>>($map))->toBeInstanceOf(
+      ImmMap::class,
+    );
+    expect(matches<\ConstMap<int, IntishStringEnum>>($map))->toBeInstanceOf(
+      ImmMap::class,
+    );
+
+    $vector = Vector {1};
+    expect(matches<\ConstVector<IntishStringEnum>>($vector))->toBeInstanceOf(
+      ImmVector::class,
+    );
   }
 }

--- a/tests/CollectionSpecOdditiesTest.hack
+++ b/tests/CollectionSpecOdditiesTest.hack
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (c) 2016, Fred Emmott
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\TypeAssert;
+
+use namespace Facebook\TypeSpec;
+use type Facebook\HackTest\HackTest;
+use type Facebook\TypeSpec\TypeSpec;
+use type Facebook\TypeAssert\TestFixtures\IntishStringEnum;
+use function Facebook\FBExpect\expect;
+
+final class CollectionSpecOdditiesTest extends HackTest {
+  public function testContainerSpecsDisregardInnerSpecAndReturnTheIdenticalObject(
+  ): void {
+    $set = Set {1};
+    expect(matches<\ConstSet<IntishStringEnum>>($set))->toEqual($set);
+
+    $map = Map {1 => 1};
+    expect(matches<\ConstMap<IntishStringEnum, int>>($map))->toEqual($map);
+    expect(matches<\ConstMap<int, IntishStringEnum>>($map))->toEqual($map);
+
+    $vector = Vector {1};
+    expect(matches<\ConstVector<IntishStringEnum>>($vector))->toEqual($vector);
+  }
+}

--- a/tests/fixtures/IntishStringEnum.hack
+++ b/tests/fixtures/IntishStringEnum.hack
@@ -1,0 +1,19 @@
+/*
+ *  Copyright (c) 2016, Fred Emmott
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\TypeAssert\TestFixtures;
+
+/**
+ * This enum exists to make `IntishStringEnum::assert(1)` return `string(1) "1"`.
+ * `EnumSpec->assertType(): T` may return a different type under these conditions.
+ */
+enum IntishStringEnum: string {
+  ONE = '1';
+}


### PR DESCRIPTION
Map and Vector modified a local `$changed` inside of a lambda. This local was captured by value, so `if (!$changed)` was always taken. SetSpec used `->filter()` as a foreach and ignored the return value of `->assertType()`.